### PR TITLE
Add postcss-prefix-selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.5.6
+> *(Oct 1st/2015)*
+- Adds [`postcss-prefix-selector`](https://github.com/jonathanong/postcss-prefix-selector)
+
 ### v1.5.5
 > *(Sep 29th/2015)*
 - Adds [`postcss-nesting`](https://github.com/jonathantneal/postcss-nesting)

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -134,7 +134,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [travco](https://github.com/travco)  |  [`postcss-extend`](https://github.com/travco/postcss-extend)
 [WolfgangKluge](https://github.com/WolfgangKluge)  |  [`postcss-media-variables`](https://github.com/WolfgangKluge/postcss-media-variables)
 [vitkarpov](https://github.com/vitkarpov)  |  [`postcss-host`](https://github.com/vitkarpov/postcss-host)
-[GitScrum](https://github.com/GitScrum)  |  [`postcss-for-variables`](https://github.com/GitScrum/postcss-for-variables)
+[jonathanong](https://github.com/jonathanong)  |  [`postcss-prefix-selector`](https://github.com/jonathanong/postcss-prefix-selector)
 [twbs](https://github.com/twbs)  |  [`mq4-hover-shim`](https://github.com/twbs/mq4-hover-shim)
 [whitneyit](https://github.com/whitneyit)  |  [`postcss-strip-units`](https://github.com/whitneyit/postcss-strip-units)
 [Rycochet](https://github.com/Rycochet)  |  [`postcss-epub`](https://github.com/Rycochet/postcss-epub)
@@ -201,5 +201,6 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [macropodhq](https://github.com/macropodhq)  |  [`postcss-local-constants`](https://github.com/macropodhq/postcss-local-constants)
 [SlexAxton](https://github.com/SlexAxton)  |  [`colorguard`](https://github.com/SlexAxton/css-colorguard)
 [rtsao](https://github.com/rtsao)  |  [`postcss-match`](https://github.com/rtsao/postcss-match)
+[GitScrum](https://github.com/GitScrum)  |  [`postcss-for-variables`](https://github.com/GitScrum/postcss-for-variables)
 [alex499](https://github.com/alex499)  |  [`postcss-image-set`](https://github.com/alex499/postcss-image-set)
 <!-- END -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugins",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A consolidated list of PostCSS plugins in an ready-to-use format.",
   "main": "index.js",
   "repository": {

--- a/plugins.json
+++ b/plugins.json
@@ -1907,5 +1907,14 @@
       "media-queries"
     ],
     "author": "jonathantneal"
+  },
+  {
+    "name": "postcss-prefix-selector",
+    "description": "that prefixes every rule with a selector.",
+    "url": "https://github.com/jonathanong/postcss-prefix-selector",
+    "tags": [
+      "other"
+    ],
+    "author": "jonathanong"
   }
 ]


### PR DESCRIPTION
`postcss-prefix-selector` is a plugin that prefixes selectors. It's useful for when you want to namespace your styles bundle so they don't bleed outside of scope.