### PR TITLE
Adding fonts as a tag to postcss-pxtorem

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1156,6 +1156,7 @@
     "url": "https://github.com/cuth/postcss-pxtorem",
     "description": "Converts pixel units to rem.",
     "tags": [
+      "fonts",
       "other"
     ],
     "author": "cuth"


### PR DESCRIPTION
Rem units are dependent on the font size of the root element.