### PR TITLE
Add postcss-pseudo-classes to the plugins repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.6.2
+> *(Dec 29th/2015)*
+- Adds [`postcss-pseudo-classes`](https://github.com/giuseppeg/postcss-pseudo-classes)
+
 ### v1.6.1
 > *(Dec 23rd/2015)*
 - Adds [`asd`](https://github.com/sajd/askjdh)

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -225,7 +225,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [vitkarpov](https://github.com/vitkarpov)  |  [`postcss-host`](https://github.com/vitkarpov/postcss-host)
 [SlexAxton](https://github.com/SlexAxton)  |  [`colorguard`](https://github.com/SlexAxton/css-colorguard)
 [WolfgangKluge](https://github.com/WolfgangKluge)  |  [`postcss-media-variables`](https://github.com/WolfgangKluge/postcss-media-variables)
-[sajd](https://github.com/sajd)  |  [`asd`](https://github.com/sajd/askjdh)
+[giuseppeg](https://github.com/giuseppeg)  |  [`postcss-pseudo-classes`](https://github.com/giuseppeg/postcss-pseudo-classes)
 [jonathanong](https://github.com/jonathanong)  |  [`postcss-prefix-selector`](https://github.com/jonathanong/postcss-prefix-selector)
 [geut](https://github.com/geut)  |  [`postcss-copy`](https://github.com/geut/postcss-copy)
 [makotot](https://github.com/makotot)  |  [`postcss-line-height-px-to-unitless`](https://github.com/makotot/postcss-line-height-px-to-unitless)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugins",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A consolidated list of PostCSS plugins in an ready-to-use format.",
   "main": "index.js",
   "repository": {

--- a/plugins.json
+++ b/plugins.json
@@ -2662,5 +2662,15 @@
     ],
     "author": "Code-Y",
     "stars": 4
+  },
+  {
+    "name": "postcss-pseudo-classes",
+    "description": "to add in companion classes where pseudo-selectors are used (useful for testing).",
+    "url": "https://github.com/giuseppeg/postcss-pseudo-classes",
+    "tags": [
+      "debug",
+      "other"
+    ],
+    "author": "giuseppeg"
   }
 ]


### PR DESCRIPTION
Hey there,
I wrote a port of [rework-pseudo-classes](https://github.com/SlexAxton/rework-pseudo-classes) with some small changes.

Given some pseudo-classes this plugin generates companion css classes that can be used for testing.

E.g.

```css
.foo:hover {
  text-decoration: underline;
}
```

yields

```css
.foo:hover,
.foo.\:hover {
  text-decoration: underline;
}
```

In your html then you'd use it as follow:

```html
<button class="foo :hover">hello</button>
```