### PR TITLE
Add a media-queries tag for filter-mq plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2720,7 +2720,8 @@
     "url": "https://github.com/simeydotme/postcss-filter-mq",
     "author": "simeydotme",
     "tags": [
-      "optimizations"
+      "optimizations",
+      "media-queries"
     ],
     "stars": 3
   },


### PR DESCRIPTION
I couldn't find filter-mq in the media queries list on postcss.parts; I guess when the postcss.parts was created, the plugins were scraped from the postcss main repo, however it seems no additional meta data was added.

I just updated filter-mq to have additional media-query tag :)
let me know if you want/need me to run the update/bump scripts.

Cheers, Si.