### PR TITLE
add postcss-display-inline-block

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -295,4 +295,5 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [Chapabu](https://github.com/Chapabu)  |  [`postcss-flexbox-unboxer`](https://github.com/Chapabu/postcss-flexbox-unboxer)
 [nucliweb](https://github.com/nucliweb)  |  [`postcss-magic-animations`](https://github.com/nucliweb/postcss-magic-animations)
 [cbas](https://github.com/cbas)  |  [`postcss-imperial`](https://github.com/cbas/postcss-imperial)
+[aemoe](https://github.com/aemoe)  |  [`postcss-display-inline-block`](https://github.com/aemoe/postcss-display-inline-block)
 <!-- END -->

--- a/plugins.json
+++ b/plugins.json
@@ -3089,5 +3089,14 @@
     "tags": [
       "optimizations"
     ]
+  },
+  {
+    "name": "postcss-display-inline-blcok",
+    "description": "PostCSS plugin to add display:inline-block hacker for IE8.",
+    "url": "https://github.com/aemoe/postcss-display-inline-block",
+    "author": "aemoe",
+    "tags": [
+      "other"
+    ]
   }
 ]


### PR DESCRIPTION
PostCSS plugin to add display:inline-block hacker for IE8 