### PR TITLE
add grid-kiss

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -349,4 +349,5 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [mystrdat](https://github.com/mystrdat)  |  [`postcss-inrule`](https://github.com/salsita/postcss-inrule)
 [git-slim](https://github.com/git-slim)  |  [`postcss-random`](https://github.com/git-slim/postcss-random)
 [bameda](https://github.com/bameda)  |  [`postcss-andalusian-stylesheets`](https://github.com/bameda/postcss-andalusian-stylesheets)
+[sylvainpolletvillard](https://github.com/sylvainpolletvillard)  |  [`grid-kiss`](https://github.com/sylvainpolletvillard/postcss-grid-kiss)
 <!-- END -->

--- a/plugins.json
+++ b/plugins.json
@@ -3674,7 +3674,7 @@
   {
     "name": "grid-kiss",
     "description": "transforms ASCII-art grids into CSS Grid layout.",
-    "url": "https://github.com/sylvainpolletvillard/postcss-plugins",
+    "url": "https://github.com/sylvainpolletvillard/postcss-grid-kiss",
     "author": "sylvainpolletvillard",
     "tags": [
       "grids"

--- a/plugins.json
+++ b/plugins.json
@@ -3670,5 +3670,14 @@
       "extensions"
     ],
     "stars": 2
+  },
+  {
+    "name": "grid-kiss",
+    "description": "transforms ASCII-art grids into CSS Grid layout.",
+    "url": "https://github.com/sylvainpolletvillard/postcss-plugins",
+    "author": "sylvainpolletvillard",
+    "tags": [
+      "grids"
+    ]
   }
 ]


### PR DESCRIPTION
Hi there,

Here's another plugin for the collection. 

It follows all the PostCSS guidelines as far as I know, except the Node 0.12 requirement. The source code is written is ES6 which makes Node 6.0.0 the minimal requirement. I guess I could add babel to transpile it to ES5 and make it run on 0.12, but I do not expect this to be useful. See, this plugin outputs Grid layout properties which are a candidate recommendation running only on Chrome Canary and Firefox Nightly. So it is very unlikely that anyone playing with this has a 0.12 Node setup, or ships this into production. 0.12 LTS ends soon and when Grid layout will be available in major browsers, Node 6 will probably be the oldest active LTS. Anyway, if you insist on 0.12 support, I'll see what I can do.

Thanks !