### PR TITLE
Updating postcss-google-color author info, adding postcss-timing-function and adding postcss-font-vsize

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -290,7 +290,9 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 [giuseppeg](https://github.com/giuseppeg)   |    [`postcss-pseudo-classes`](https://github.com/giuseppeg/postcss-pseudo-classes)   |   22
 [h0tc0d3](https://github.com/h0tc0d3)   |    [`postcss-hamster`](https://github.com/h0tc0d3/postcss-hamster)   |   22
 [HashanP](https://github.com/HashanP)   |    [`postcss-spiffing`](https://github.com/HashanP/postcss-spiffing)   |   72
-[hegedusarpad](https://github.com/hegedusarpad)   |    [`postcss-google-color`](https://bitbucket.org/hegedusarpad/postcss-google-color)   |   0
+[arpadHegedus](https://github.com/arpadHegedus)   |    [`postcss-google-color`](https://github.com/arpadHegedus/postcss-google-color)   |   0
+   |    [`postcss-font-vsize`](https://github.com/arpadHegedus/postcss-font-vsize)   |   0
+   |    [`postcss-timing-function`](https://github.com/arpadHegedus/postcss-timing-function)   |   0
 [HoBi](https://github.com/HoBi)   |    [`postcss-czech-stylesheets`](https://github.com/HoBi/postcss-czech-stylesheets)   |   27
 [hudochenkov](https://github.com/hudochenkov)   |    [`postcss-sorting`](https://github.com/hudochenkov/postcss-sorting)   |   238
 [iahu](https://github.com/iahu)   |    [`postcss-font-normalize`](https://github.com/iahu/postcss-font-normalize)   |   5

--- a/plugins.json
+++ b/plugins.json
@@ -3808,11 +3808,31 @@
   },
   {
     "name": "postcss-google-color",
-    "description": "PostCSS plugin for easily invoking the colors on the Google Material design color palette.",
-    "author": "hegedusarpad",
-    "url": "https://bitbucket.org/hegedusarpad/postcss-google-color",
+    "description": "A postcss plugin for easily invoking the colors on the Google Material design color palette",
+    "author": "arpadHegedus",
+    "url": "https://github.com/arpadHegedus/postcss-google-color",
     "tags": [
       "color"
+    ],
+    "stars": 0
+  },
+  {
+    "name": "postcss-font-vsize",
+    "description": "A postcss plugin to add viewport relative font size with minimum and maximum values",
+    "author": "arpadHegedus",
+    "url": "https://github.com/arpadHegedus/postcss-font-vsize",
+    "tags": [
+      "extensions", "fonts", "shortcuts"
+    ],
+    "stars": 0
+  },
+  {
+    "name": "postcss-timing-function",
+    "description": "A postcss plugin to add other common named timing functions without having to remember bezier values",
+    "author": "arpadHegedus",
+    "url": "https://github.com/arpadHegedus/postcss-timing-function",
+    "tags": [
+      "extensions", "shortcuts"
     ],
     "stars": 0
   },


### PR DESCRIPTION
I am the author of a previously added plugin "postcss-google-color". At the time I've added the plugin, I did not have a github repo for it, only a bitbucket one. I've updated npmjs as well with the github repo now and also the author and plugins list here with postcss-plugins. 

I also would like to add two of my new plugins.

Updating postcss-google-color author info
Adding postcss-timing-function
Adding postcss-font-vsize