### PR TITLE
Add plugin postcss-fontsize

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -375,6 +375,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[Pustur](https://github.com/Pustur)   |    [`postcss-italian-stylesheets`](https://github.com/Pustur/postcss-italian-stylesheets)   |   3|
 |[redaxmedia](https://github.com/redaxmedia)   |    [`postcss-harmonize`](https://github.com/redaxmedia/postcss-harmonize)   |   0|
 |[rezoh](https://github.com/rezoh)   |    [`postcss-at-debug`](https://github.com/rezoh/postcss-at-debug)   |   1|
+|[richbachman](https://github.com/richbachman)   |    [`postcss-fontsize`](https://github.com/richbachman/postcss-fontsize)   |   0|
 |[robwierzbowski](https://github.com/robwierzbowski)   |    [`pixrem`](https://github.com/robwierzbowski/node-pixrem)   |   183|
 |[rominmx](https://github.com/rominmx)   |    [`postcss-compact-mq`](https://github.com/rominmx/postcss-compact-mq)   |   7|
 |[ronnyamarante](https://github.com/ronnyamarante)   |    [`postcss-selector-prefixer`](https://github.com/ronnyamarante/postcss-selector-prefixer)   |   2|

--- a/plugins.json
+++ b/plugins.json
@@ -4479,5 +4479,15 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-fontsize",
+    "description": "Generates rem unit font-size and line-height with px fallbacks.",
+    "author": "richbachman",
+    "url": "https://github.com/richbachman/postcss-fontsize",
+    "tags": [
+      "fonts"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
Submitting a new PostCSS plugin for your approval. This is based off a Sass mixin that I used a lot. It generates and rem based font-size and line-height from a number value. The plugin also generates a px fallback for older browsers. So for fontsize: 16, the plugin will generate the following:

{ font-size: 16px;line-height: 24px;font-size: 1rem;line-height: 1.5rem; }