### PR TITLE
Add postcss-class-name-shortener

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -366,6 +366,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[macropodhq](https://github.com/macropodhq)   |    [`postcss-constants`](https://github.com/macropodhq/postcss-constants)   |   59|
 |[makotot](https://github.com/makotot)   |    [`postcss-line-height-px-to-unitless`](https://github.com/makotot/postcss-line-height-px-to-unitless)   |   1|
 |[maraisr](https://github.com/maraisr)   |    [`postcss-grouper`](https://github.com/maraisr/postcss-grouper)   |   4|
+|[mbrandau](https://github.com/mbrandau)   |    [`postcss-class-name-shortener`](https://github.com/mbrandau/postcss-class-name-shortener)   |   0|
 |[megatolya](https://github.com/megatolya)   |    [`postcss-will-change-transition`](https://github.com/megatolya/postcss-will-change-transition)   |   11|
 |[meltifa](https://github.com/meltifa)   |    [`postcss-pixel-to-viewport`](https://github.com/meltifa/postcss-pixel-to-viewport)   |   1|
 |[michelemazzucco](https://github.com/michelemazzucco)   |    [`postcss-border-shortcut`](https://github.com/michelemazzucco/postcss-border-shortcut)   |   7|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-plugins",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins.json
+++ b/plugins.json
@@ -4622,5 +4622,15 @@
       "fun"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-class-name-shortener",
+    "description": "that shortens CSS class names to optimize website performance",
+    "author": "mbrandau",
+    "url": "https://github.com/mbrandau/postcss-class-name-shortener",
+    "tags": [
+      "optimizations"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
PostCSS plugin that shortens CSS class names to optimize website performance.

https://github.com/mbrandau/postcss-class-name-shortener
https://www.npmjs.com/package/postcss-class-name-shortener