### PR TITLE
Add postcss-font-format-keywords

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -434,6 +434,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[tsm91](https://github.com/tsm91)   |    [`postcss-filter-stream`](https://github.com/tsm91/postcss-filter-stream)   |   12|
 |[twbs](https://github.com/twbs)   |    [`mq4-hover-shim`](https://github.com/twbs/mq4-hover-shim)   |   98|
 |[unlight](https://github.com/unlight)   |    [`postcss-import-url`](https://github.com/unlight/postcss-import-url)   |   16|
+|[valtlai](https://github.com/valtlai)   |    [`postcss-font-format-keywords`](https://github.com/valtlai/postcss-font-format-keywords)   |   0|
 |[vital-software](https://github.com/vital-software)   |    [`postcss-rgb-to-rgba`](https://github.com/vital-software/postcss-rgb-to-rgba)   |   0|
 |[vitaliy-bobrov](https://github.com/vitaliy-bobrov)   |    [`postcss-register-custom-props`](https://github.com/vitaliy-bobrov/postcss-register-custom-props)   |   15|
 |[VitaliyR](https://github.com/VitaliyR)   |    [`postcss-esplit`](https://github.com/VitaliyR/postcss-esplit)   |   10|

--- a/plugins.json
+++ b/plugins.json
@@ -4789,5 +4789,16 @@
       "optimizations"
     ],
     "stars": 1
+  },
+  {
+    "name": "postcss-font-format-keywords",
+    "description": "supports keywords in `@font-face` rule's `format()` function",
+    "author": "valtlai",
+    "url": "https://github.com/valtlai/postcss-font-format-keywords",
+    "tags": [
+      "fonts",
+      "future"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
This PR adds [postcss-font-format-keywords](/valtlai/postcss-font-format-keywords) plugin (and my author row).