### PR TITLE
Add plugin postcss-hairlines

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -464,3 +464,4 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[ZeeCoder](https://github.com/ZeeCoder)   |    [`@zeecoder/postcss-container-query`](https://github.com/ZeeCoder/container-query)   |   104|
 |[zephraph](https://github.com/zephraph)   |    [`postcss-process-comments`](https://github.com/zephraph/postcss-process-comments)   |   0|
 |[zgreen](https://github.com/zgreen)   |    [`postcss-critical-css`](https://github.com/zgreen/postcss-critical-css)   |   64|
+|[zhoucheng](https://github.com/zhouchengi)   |    [`postcss-hairlines`](https://github.com/zhouchengi/postcss-hairlines)   |   0|

--- a/plugins.json
+++ b/plugins.json
@@ -4933,5 +4933,16 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-hairlines",
+    "description": "transform your border to retina hairlines",
+    "author": "zhoucheng",
+    "url": "https://github.com/zhouchengi/postcss-hairlines",
+    "tags": [
+      "optimizations",
+      "fallbacks"
+    ],
+    "stars": 0
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -4936,7 +4936,7 @@
   },
   {
     "name": "postcss-hairlines",
-    "description": "transform your border to retina hairlines",
+    "description": "Transform your border to retina hairlines",
     "author": "zhoucheng",
     "url": "https://github.com/zhouchengi/postcss-hairlines",
     "tags": [


### PR DESCRIPTION
Solve the problem that 1px border is too thick on iOS
Before:
``` css
.foo {
  border: 1px solid red;
}
```
After:
``` css
.foo {
  border: 1px solid red;
}
.hairlines .foo {
  border-width: 0.5px;
}
```