### PR TITLE
Add postcss-prefix-keyframe

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -118,11 +118,11 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |   |    [`postcss-negative-padding`](https://github.com/limitlessloop/postcss-negative-padding)   |   4|
 |   |    [`postcss-proportional-spacing`](https://github.com/limitlessloop/postcss-proportional-spacing)   |   1|
 |   |    [`postcss-exact-width`](https://github.com/limitlessloop/postcss-exact-width)   |   1|
-|[ezavile](https://github.com/ezavile)   |    [`postcss-typescript-css`](https://github.com/ezavile/postcss-plugins/tree/master/packages/typescript-css)   |   9|
-|   |    [`postcss-text-transform`](https://github.com/ezavile/postcss-plugins/tree/master/packages/text-transform)   |   9|
-|   |    [`postcss-console`](https://github.com/ezavile/postcss-plugins/tree/master/packages/console)   |   9|
-|   |    [`postcss-token-utility`](https://github.com/ezavile/postcss-plugins/tree/master/packages/token-utility)   |   9|
-|   |    [`postcss-button-builder`](https://github.com/ezavile/postcss-plugins/tree/master/packages/button-builder)   |   9|
+|[ezavile](https://github.com/ezavile)   |    [`postcss-typescript-css`](https://github.com/ezavile/postcss-typescript-css)   |   10|
+|   |    [`postcss-text-transform`](https://github.com/ezavile/postcss-plugins/tree/master/packages/text-transform)   |   0|
+|   |    [`postcss-console`](https://github.com/ezavile/postcss-plugins/tree/master/packages/console)   |   0|
+|   |    [`postcss-token-utility`](https://github.com/ezavile/postcss-plugins/tree/master/packages/token-utility)   |   0|
+|   |    [`postcss-button-builder`](https://github.com/ezavile/postcss-plugins/tree/master/packages/button-builder)   |   0|
 |[admdh](https://github.com/admdh)   |    [`postcss-simple-grid`](https://github.com/admdh/postcss-simple-grid)   |   18|
 |   |    [`postcss-high-contrast`](https://github.com/admdh/postcss-high-contrast)   |   108|
 |   |    [`postcss-increase-text-sizes`](https://github.com/admdh/postcss-increase-text-sizes)   |   16|
@@ -272,6 +272,8 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |   |    [`postcss-secmodify`](https://github.com/travco/postcss-secmodify)   |   1|
 |[valtlai](https://github.com/valtlai)   |    [`postcss-font-format-keywords`](https://github.com/valtlai/postcss-font-format-keywords)   |   5|
 |   |    [`postcss-color-image`](https://github.com/valtlai/postcss-color-image)   |   1|
+|[VitaliyR](https://github.com/VitaliyR)   |    [`postcss-esplit`](https://github.com/VitaliyR/postcss-esplit)   |   8|
+|   |    [`postcss-prefix-keyframe`](https://github.com/VitaliyR/postcss-prefix-keyframe)   |   0|
 |[yuezk](https://github.com/yuezk)   |    [`postcss-urlrev`](https://github.com/yuezk/postcss-urlrev)   |   18|
 |   |    [`postcss-filter-gradient`](https://github.com/yuezk/postcss-filter-gradient)   |   16|
 |[yunusga](https://github.com/yunusga)   |    [`postcss-momentum-scrolling`](https://github.com/yunusga/postcss-momentum-scrolling)   |   63|
@@ -466,7 +468,6 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[unlight](https://github.com/unlight)   |    [`postcss-import-url`](https://github.com/unlight/postcss-import-url)   |   43|
 |[vital-software](https://github.com/vital-software)   |    [`postcss-rgb-to-rgba`](https://github.com/vital-software/postcss-rgb-to-rgba)   |   0|
 |[vitaliy-bobrov](https://github.com/vitaliy-bobrov)   |    [`postcss-register-custom-props`](https://github.com/vitaliy-bobrov/postcss-register-custom-props)   |   20|
-|[VitaliyR](https://github.com/VitaliyR)   |    [`postcss-esplit`](https://github.com/VitaliyR/postcss-esplit)   |   8|
 |[vitkarpov](https://github.com/vitkarpov)   |    [`postcss-host`](https://github.com/vitkarpov/postcss-host)   |   4|
 |[vkalinichev](https://github.com/vkalinichev)   |    [`postcss-rtl`](https://github.com/vkalinichev/postcss-rtl)   |   142|
 |[vovanbo](https://github.com/vovanbo)   |    [`css2modernizr`](https://github.com/vovanbo/css2modernizr)   |   73|

--- a/plugins.json
+++ b/plugins.json
@@ -5118,5 +5118,15 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-prefix-keyframe",
+    "description": "for prefixing keyframes and animation names",
+    "author": "VitaliyR",
+    "url": "https://github.com/VitaliyR/postcss-prefix-keyframe",
+    "tags": [
+      "other"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
Added new plugin for prefixing `@keyframe` & used animation name within CSS properties `animation` (shorthand) or explicit `animation-name`