### PR TITLE
Add postcss-flex-value

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -294,6 +294,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[alex499](https://github.com/alex499)   |    [`postcss-image-set`](https://github.com/alex499/postcss-image-set)   |   20|
 |[alexandr-solovyov](https://github.com/alexandr-solovyov)   |    [`postcss-responsive-properties`](https://github.com/alexandr-solovyov/postcss-responsive-properties)   |   12|
 |[anandthakker](https://github.com/anandthakker)   |    [`doiuse`](https://github.com/anandthakker/doiuse)   |   1007|
+|[anc95](https://github.com/anc95)   |    [`postcss-flex-value`](https://github.com/anc95/postcss-flex-value)   |   0|
 |[andrasna](https://github.com/andrasna)   |    [`postcss-baseline-grid-overlay`](https://github.com/andrasna/postcss-baseline-grid-overlay)   |   5|
 |[andylbrummer](https://github.com/andylbrummer)   |    [`postcss-subtle`](https://github.com/standardbeagle/postcss-subtle)   |   1|
 |[AoDev](https://github.com/AoDev)   |    [`css-byebye`](https://github.com/AoDev/css-byebye)   |   56|

--- a/plugins.json
+++ b/plugins.json
@@ -5265,5 +5265,15 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-flex-value",
+    "description": "A postcss plugin to transform flex value such as \"start\" to \"flex-start\"",
+    "author": "anc95",
+    "url": "https://github.com/anc95/postcss-flex-value",
+    "tags": [
+      "other"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
I would like to add postcss-flex-value plugin.`postcss-flex-value` is a plugin of [postcss](https://postcss.org/), it transforms flex's "start" to "flex-start" to avoid issue like [start value has mixed support, consider using flex-start instead](https://github.com/mozilla/addons-frontend/issues/7312).