### PR TITLE
feat: add postcss-hocus-pocus

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -315,6 +315,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[bmds](https://github.com/bmds)   |    [`postcss-logical-props`](https://github.com/bmds/postcss-logical-props)   |   7|
 |[borodean](https://github.com/borodean)   |    [`postcss-assets`](https://github.com/borodean/postcss-assets)   |   541|
 |[btholt](https://github.com/btholt)   |    [`postcss-colorblind`](https://github.com/btholt/postcss-colorblind)   |   333|
+|[cadomac](https://github.com/cadomac)   |    [`postcss-hocus-pocus`](https://github.com/cadomac/postcss-hocus-pocus)   |   0|
 |[casey6](https://github.com/casey6)   |    [`postcss-redundant-color-vars`](https://github.com/caseyjacobson/postcss-redundant-color-vars)   |   13|
 |[cbas](https://github.com/cbas)   |    [`postcss-imperial`](https://github.com/cbas/postcss-imperial)   |   31|
 |[cbracco](https://github.com/cbracco)   |    [`postcss-remove-root`](https://github.com/cbracco/postcss-remove-root)   |   9|

--- a/plugins.json
+++ b/plugins.json
@@ -5265,5 +5265,16 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-hocus-pocus",
+    "description": "Provides shorthand to combine :hover and :focus using :hocus, and add :active using :pocus! Forked from postcss-hocus.",
+    "author": "cadomac",
+    "url": "https://github.com/cadomac/postcss-hocus-pocus",
+    "tags": [
+      "fun",
+      "shortcuts"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
This adds `postcss-hocus-pocus` to the plugins list. It is a fork of `postcss-hocus` by [Kilian Valkhof](https://github.com/Kilian).