### PR TITLE
Feature postcss-pxrem-funtion plugin for postcss.

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -292,6 +292,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[ahtohbi4](https://github.com/ahtohbi4)   |    [`postcss-bgimage`](https://github.com/ahtohbi4/postcss-bgimage)   |   12|
 |[aleray](https://github.com/aleray)   |    [`postcss-single-line`](https://github.com/aleray/postcss-single-line)   |   3|
 |[alex499](https://github.com/alex499)   |    [`postcss-image-set`](https://github.com/alex499/postcss-image-set)   |   20|
+|[AlexanderMar21](https://github.com/AlexanderMar21)   |    [`postcss-pxrem-function`](https://github.com/AlexanderMar21/postcss-pxrem-function)   |   0|
 |[alexandr-solovyov](https://github.com/alexandr-solovyov)   |    [`postcss-responsive-properties`](https://github.com/alexandr-solovyov/postcss-responsive-properties)   |   14|
 |[anandthakker](https://github.com/anandthakker)   |    [`doiuse`](https://github.com/anandthakker/doiuse)   |   1058|
 |[anc95](https://github.com/anc95)   |    [`postcss-flex-value`](https://github.com/anc95/postcss-flex-value)   |   0|

--- a/plugins.json
+++ b/plugins.json
@@ -5330,7 +5330,7 @@
   },
   {
     "name": "postcss-pxrem-function",
-    "description": "that transforms the pxRem() function into rem values.",
+    "description": "A plugin that transforms the pxRem() function into rem values.",
     "author": "AlexanderMar21",
     "url": "https://github.com/AlexanderMar21/postcss-pxrem-function",
     "tags": [

--- a/plugins.json
+++ b/plugins.json
@@ -5327,5 +5327,15 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-pxrem-function",
+    "description": "that transforms the pxRem() function into rem values.",
+    "author": "AlexanderMar21",
+    "url": "https://github.com/AlexanderMar21/postcss-pxrem-function",
+    "tags": [
+      "optimizations"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
A plugin that you can use pxRem( ) to convert px values into rem values. 