### PR TITLE
feat: adding postcss-color-scheme & postcss-space-between to list

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -274,6 +274,8 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |   |    [`postcss-color-image`](https://github.com/valtlai/postcss-color-image)   |   3|
 |[VitaliyR](https://github.com/VitaliyR)   |    [`postcss-esplit`](https://github.com/VitaliyR/postcss-esplit)   |   8|
 |   |    [`postcss-prefix-keyframe`](https://github.com/VitaliyR/postcss-prefix-keyframe)   |   1|
+|[vnphanquang](https://github.com/vnphanquang)   |    [`postcss-color-scheme`](https://github.com/vnphanquang/postcss-color-scheme)   |   0|
+|   |    [`postcss-space-between`](https://github.com/vnphanquang/postcss-space-between)   |   0|
 |[yuezk](https://github.com/yuezk)   |    [`postcss-urlrev`](https://github.com/yuezk/postcss-urlrev)   |   19|
 |   |    [`postcss-filter-gradient`](https://github.com/yuezk/postcss-filter-gradient)   |   16|
 |[yunusga](https://github.com/yunusga)   |    [`postcss-momentum-scrolling`](https://github.com/yunusga/postcss-momentum-scrolling)   |   68|

--- a/plugins.json
+++ b/plugins.json
@@ -5327,5 +5327,27 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "postcss-color-scheme",
+    "description": "scope rules according to prefers-color-scheme",
+    "author": "vnphanquang",
+    "url": "https://github.com/vnphanquang/postcss-color-scheme",
+    "tags": [
+      "color",
+      "media-queries"
+    ],
+    "stars": 0
+  },
+  {
+    "name": "postcss-space-between",
+    "description": "add horizontal or vertical spacing between direct children",
+    "author": "vnphanquang",
+    "url": "https://github.com/vnphanquang/postcss-space-between",
+    "tags": [
+      "other",
+      "shortcuts"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
As the title states, this is a request to add these plugins to the list:

- [postcss-color-scheme](https://github.com/vnphanquang/postcss-color-scheme)
- [postcss-space-between](https://github.com/vnphanquang/postcss-space-between)

Thank you for the good work and clear guidelines!