### PR TITLE
feat: Add wrap-up-layer

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -476,6 +476,7 @@ Below is a list of all the wonderful people who make PostCSS plugins.
 |[timche](https://github.com/timche)   |    [`postcss-german-stylesheets`](https://github.com/timche/postcss-german-stylesheets)   |   51|
 |[titancat](https://github.com/titancat)   |    [`postcss-define-function`](https://github.com/titancat/postcss-define-function)   |   25|
 |[tivac](https://github.com/tivac)   |    [`postcss-fixie`](https://github.com/tivac/fixie)   |   44|
+|[TM-SunnyDay](https://github.com/TM-SunnyDay)   |    [`wrap-up-layer`](https://github.com/web-baseline/postcss-wrap-up-layer)   |   0|
 |[toomuchdesign](https://github.com/toomuchdesign)   |    [`postcss-nested-ancestors`](https://github.com/toomuchdesign/postcss-nested-ancestors)   |   90|
 |[totora0155](https://github.com/totora0155)   |    [`postcss-namespace`](https://github.com/totora0155/postcss-namespace)   |   16|
 |[troch](https://github.com/troch)   |    [`postcss-responsive-values`](https://github.com/troch/postcss-responsive-values)   |   4|

--- a/plugins.json
+++ b/plugins.json
@@ -5327,5 +5327,16 @@
       "other"
     ],
     "stars": 0
+  },
+  {
+    "name": "wrap-up-layer",
+    "description": "PostCSS plugin to add cascade layers to CSS",
+    "author": "TM-SunnyDay",
+    "url": "https://github.com/web-baseline/postcss-wrap-up-layer",
+    "tags": [
+      "extensions",
+      "pack"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
This plugin wraps a cascading layer on each matched file.  

When using style libraries or component libraries in web development, this plugin can be used to add cascading layer support for these uncontrolled style files.